### PR TITLE
ftplugin/c.vim: C standards respectful commentstring

### DIFF
--- a/ftplugin/c.vim
+++ b/ftplugin/c.vim
@@ -1,1 +1,5 @@
-set cms=//%s
+if exists('c_no_c99') || exists('commented_c89_comments')
+	set commentstring=/*%s*/
+else
+	set commentstring=//%s
+endif


### PR DESCRIPTION
i think that it is also should be mentioned somewhere in README that it can be configured through
```vim
let commented_c89_comments = v:true
```